### PR TITLE
Fixed chat container stylings and horizontal and vertical scrolls

### DIFF
--- a/frontend/src/chat/components/Chat/Chat.svelte
+++ b/frontend/src/chat/components/Chat/Chat.svelte
@@ -1,14 +1,20 @@
 <script lang="ts">
-	import {onMount} from 'svelte'
+	import {afterUpdate, onMount} from 'svelte'
 	import Message from './Message.svelte'
-	import type {ChatController, ChatSettings, Message as MessageInterface, MessageHandler} from '../../interfaces/chat'
-	import type {User} from '../../interfaces/user'
+	import type {
+		ChatController,
+		ChatSettings,
+		Message as MessageInterface,
+		MessageHandler,
+	} from '../../../common/interfaces/chat'
+	import type {User} from '../../../common/interfaces/user'
 
 	export let chatFactory: (settings: ChatSettings) => ChatController
 	export let boardId: string
 	export let roomId: string
 	export let user: User
 
+	let sidebarBody
 	let newMessageText: string = ''
 
 	let chatController: ChatController = null
@@ -31,6 +37,10 @@
 	onMount(() => {
 		chatController = chatFactory({boardId, roomId, user, messageHandler: handleNewMessage})
 	})
+
+	afterUpdate(() => {
+		sidebarBody.scrollTo(0, sidebarBody.scrollHeight)
+	})
 </script>
 
 <style>
@@ -49,7 +59,8 @@
 	.sidebar__body {
 		display: flex;
 		flex-direction: column;
-		justify-content: flex-end;
+		overflow-x: hidden;
+		overflow-y: auto;
 		height: calc(100% - 120px);
 		padding: 0 24px;
 	}
@@ -65,7 +76,7 @@
 
 <div class="sidebar__container">
 	<div class="sidebar__header"><span class="miro-h2">Breakout Chat</span></div>
-	<div class="sidebar__body">
+	<div class="sidebar__body" bind:this={sidebarBody}>
 		{#each messages as message}
 			<Message {message} />
 		{/each}

--- a/frontend/src/chat/components/Chat/Message.svelte
+++ b/frontend/src/chat/components/Chat/Message.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-	import type {Message} from '../../interfaces/chat'
+	import type {
+		Message
+	} from '../../../common/interfaces/chat'
 	export let message: Message
 </script>
 
@@ -10,12 +12,17 @@
 		margin: 6px 0;
 	}
 
+	.message__container:first-child {
+		margin-top: auto;
+	}
+
 	.message__header {
 		margin-top: 12px;
 	}
 
 	.message__text {
 		margin: 6px 0px 0px 0px;
+		word-wrap: break-word;
 	}
 </style>
 


### PR DESCRIPTION
### **Broken messages container styling and scrolling**
Trello ticket with requirements - https://trello.com/c/2cn8mfo0

- [x] Fixed chat container stylings that had made overlapping of messages and chat title
- [x] Fixed vertical scroll by changes in `.sidebar__body` and `.message__container:first-child` classes
- [x] Implemented automatic scrolling to the bottom of the chat when a user starts to type or send or receive a message - into [afterUpdate](https://github.com/shurupin/miro-breakout-chat-app/pull/5/files#diff-b64795e359c3f8b4e2933bbdf8b293acedb5fc4cba6b09822b6472e757cd5303) render method of `Chat.svelte`
- [x] Allowed long messages to be able to break and wrapped them the next lines and hid the horizontal scroll - [Message.svelte ](https://github.com/shurupin/miro-breakout-chat-app/pull/5/files#diff-fce41de22be52eb91ca61f9a97f42c42b139b001af515e0f7af488362d67825f)

**Finished result:**
<img src="https://user-images.githubusercontent.com/25136826/98469546-5f9ea700-21f1-11eb-9f3c-72a7e146dc67.jpg" width="50%">
